### PR TITLE
Support Generically Typed Implementations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.5",
       "license": "MIT",
       "dependencies": {
-        "typescript-rtti": "^0.4.16"
+        "typescript-rtti": "^0.5.0"
       },
       "devDependencies": {
         "chai": "^4.3.6",
@@ -2335,9 +2335,9 @@
       }
     },
     "node_modules/typescript-rtti": {
-      "version": "0.4.16",
-      "resolved": "https://registry.npmjs.org/typescript-rtti/-/typescript-rtti-0.4.16.tgz",
-      "integrity": "sha512-9W0150tNYfmfP98W5pL+wwTLpKiYLUAMViRn5O3fDrzW62fxOay4R/vfB16ramImlncN/TmaOGkZbEUnzo4umw==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/typescript-rtti/-/typescript-rtti-0.5.0.tgz",
+      "integrity": "sha512-n7jtZHd44YBhid9huWZ10VoLs0RPcB7oKKoSUDfoUzMlxyr2pGLQPiOCVjeo6mpFb1JYWhr2B2MmpbXO2yRNjw==",
       "engines": {
         "node": ">=10"
       },
@@ -4246,9 +4246,9 @@
       "integrity": "sha512-HM/hFigTBHZhLXshn9sN37H085+hQGeJHJ/X7LpBWLID/fbc2acUMfU+lGD98X81sKP+pFa9f0DZmCwB9GnbAg=="
     },
     "typescript-rtti": {
-      "version": "0.4.16",
-      "resolved": "https://registry.npmjs.org/typescript-rtti/-/typescript-rtti-0.4.16.tgz",
-      "integrity": "sha512-9W0150tNYfmfP98W5pL+wwTLpKiYLUAMViRn5O3fDrzW62fxOay4R/vfB16ramImlncN/TmaOGkZbEUnzo4umw==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/typescript-rtti/-/typescript-rtti-0.5.0.tgz",
+      "integrity": "sha512-n7jtZHd44YBhid9huWZ10VoLs0RPcB7oKKoSUDfoUzMlxyr2pGLQPiOCVjeo6mpFb1JYWhr2B2MmpbXO2yRNjw==",
       "requires": {}
     },
     "uuid": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "phantomdi",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "A dependency injection framework",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -21,7 +21,7 @@
     "mock"
   ],
   "dependencies": {
-    "typescript-rtti": "^0.4.16"
+    "typescript-rtti": "^0.5.0"
   },
   "peerDependencies": {
     "reflect-metadata": "^0.1.13"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "phantomdi",
-  "version": "0.0.6",
+  "version": "0.0.5",
   "description": "A dependency injection framework",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -21,6 +21,7 @@
     "mock"
   ],
   "dependencies": {
+    "deep-equal": "^2.0.5",
     "typescript-rtti": "^0.5.0"
   },
   "peerDependencies": {

--- a/src/injector.ts
+++ b/src/injector.ts
@@ -1,17 +1,17 @@
-import { InterfaceToken, reflect, ReflectedClass, ReflectedConstructorParameter, ReflectedFunctionParameter, ReflectedMethodParameter, ReflectedTypeRef } from 'typescript-rtti';
+import { InterfaceToken, reflect, ReflectedClass, ReflectedConstructorParameter, ReflectedFunctionParameter, ReflectedGenericRef, ReflectedMetadataTarget, ReflectedMethodParameter, ReflectedTypeRef } from 'typescript-rtti';
 import { capitalize, Constructor } from './common';
 import { Inject } from './decorators';
+import deepEqual from 'deep-equal';
 export interface Dependency<T = any> { tokens : any[]; optional? : boolean; default? : () => T; }
 
 export type Provider = (...args) => any;
 
 
 export function genericImpl<T>(type: ReflectedTypeRef, instance: T){
-  if( !type.isGeneric() ){
-    throw new Error('Provided a non-generic instance: ' + instance)
+  if( type.kind !== 'generic' ){
+    throw new Error(`TypeRef ${JSON.stringify(type || {})} kind is "${type.kind}"; must be generic.`)
   }
-  // @ts-ignore (what's the right move here?)
-  return provide( type.ref, () => instance);
+  return provide( type, () => instance);
 }
 
 function carry<T,U>(v : T, callback : (v : T) => U) {
@@ -31,6 +31,7 @@ export class Injector {
      */
     constructor(providers : [any, Provider][], parent? : Injector) {
         this.#providers = new Map(providers.filter(([token]) => !token[ALTERS]));
+        this.#generics = providers.filter(([token]) => (token instanceof ReflectedGenericRef)).map( ([token]) => token);
 
         let alterations = new Map<any, Function[]>();
         for (let [alteredToken, provider] of providers.filter(([token]) => token[ALTERS])) {
@@ -57,6 +58,7 @@ export class Injector {
     #providers = new Map<any, Function>();
     #alterations = new Map<any, Function[]>();
     #resolved = new Map<any, any>();
+    #generics = [] as ReflectedGenericRef[];
 
     /**
      * Provide an instance for the given class. 
@@ -71,11 +73,11 @@ export class Injector {
     provide(token : any, defaultValue? : any): any;
     provide(token : any, defaultValue? : any): any {
         let hasDefault = arguments.length > 1;
-
         // TODO: ask @rezonant if this is safe
-        if( token instanceof ReflectedTypeRef && token.isGeneric()){
-          // @ts-ignore
-          token = token.ref
+
+        // if it's a generic ref, lookup the specific match we put in the map
+        if( token instanceof ReflectedGenericRef && token.isGeneric()){
+          token = this.#generics.find(t => t.matchesRef(token)) || token
         }
 
         if (this.#resolved.has(token))

--- a/src/match.test.ts
+++ b/src/match.test.ts
@@ -1,0 +1,42 @@
+import 'reflect-metadata'
+import { expect } from 'chai'
+import { reflect } from 'typescript-rtti';
+import { injector, genericImpl } from './injector';
+import { it, describe } from 'razmin'
+
+
+class Dummy<T> {
+  public constructor(
+    public value: T
+  ){}
+}
+
+const implValue = { input: '123' }
+const impl = new Dummy<any>(implValue)
+
+
+describe('Generic Injector Support', () => {
+  it('can provide for multiple refs', async () => {
+    const ref1 = reflect<Dummy<any>>()
+    const ref2 = reflect<Dummy<any>>()
+
+    expect(ref1).not.to.equal(ref2)
+    const provider = genericImpl(ref1, impl)
+
+    const inj = injector([ provider ])
+    expect(inj.provide(ref1)).to.equal(impl)
+    expect(inj.provide(ref2)).to.equal(impl)
+  })
+
+  it('can invoke for multiple refs', async () => {
+    const fn = (dummy: Dummy<any>) => {
+      return dummy.value
+    }
+    
+    const provider = genericImpl(reflect<Dummy<any>>(), impl)
+
+    const inj = injector([ provider ])
+    expect(inj.invoke(null, fn)).to.equal(implValue)
+    expect(inj.invoke(null, fn)).to.equal(implValue)
+  })
+})


### PR DESCRIPTION
Brought us up to the 0.5.0 cut of rtti, and added a first stab at supporting generic tokens.

Probably a much smarter way of both creating the provider + resolving the tokens, but I was able to "break all teh tests" and then repair them with this simple approach.

Def open to feedback. But it's working on my use case really nicely, so gives me hope :)  