### PR TITLE
feat: accept function values as valid instances

### DIFF
--- a/src/injector.ts
+++ b/src/injector.ts
@@ -120,7 +120,7 @@ export class Injector {
      */
     private prepare<T>(token : any, instance : T): T {
         reflect(instance).properties
-            .filter(x => x.hasMetadata('pdi:inject'))
+            ?.filter(x => x.hasMetadata('pdi:inject'))
             .forEach(p => instance[p.name] = carry(
                 p.getMetadata('pdi:inject') ?? p.type.as('class').class, 
                 token => (p.isOptional || p.getMetadata('pdi:optional') === true) ? this.provide(token, undefined) : this.provide(token)


### PR DESCRIPTION
There is a lot of JavaScript/browser functionality that comes just shaped as a function and not an object/instance: `fetch`, `setTimeout/clearTimeout`, `atob/btoa`, `requestIdleCallback`, etc. It seems handy to be able to inject _function_ values on provisions. Does it feel ok? Any thoughts?

```ts
interface Fetch {
    (input: RequestInfo, init?: RequestInit): Promise<Response>;
}
const customFetch: Fetch = /* custom implementation */;
class HttpClient { 
    constructor(readonly fetchImpl: Fetch) {}
}

const injector = new Injector([provide(reify<Fetch>(), () => customFetch), provide(HttpClient)]);

```